### PR TITLE
feat: Define interface for array processing class

### DIFF
--- a/geekbrains/java-exceptions/ExceptionHandledArrayProcessor/src/interfaces/ArrayProcessorInterface.java
+++ b/geekbrains/java-exceptions/ExceptionHandledArrayProcessor/src/interfaces/ArrayProcessorInterface.java
@@ -1,0 +1,9 @@
+package interfaces;
+
+import exceptions.MyArraySizeException;
+import exceptions.MyArrayDataException;
+
+public interface ArrayProcessorInterface {
+    int processArray(String[][] array) throws MyArraySizeException, MyArrayDataException;
+}
+


### PR DESCRIPTION
#comment The ArrayProcessorInterface serves as a interface for class that will process arrays. It defines a single method, processArray, that requires implementation in any class that uses it

Affected: ArrayProcessorInterface