### PR TITLE
refactor: Use GameSymbol enum for game symbols

### DIFF
--- a/geekbrains/java-oop/TicTacToeAI/src/game/Game.java
+++ b/geekbrains/java-oop/TicTacToeAI/src/game/Game.java
@@ -1,6 +1,7 @@
 package game;
 
 import model.GameField;
+import model.GameSymbol;
 import player.Player;
 import player.HumanPlayer;
 import player.AIPlayer;
@@ -39,21 +40,21 @@ public class Game {
         while (true) {
             humanPlayer.makeMove(field);
             field.printField();
-            if (checkEndGame('X')) {
+            if (checkEndGame(GameSymbol.X)) {
                 break;
             }
 
             aiPlayer.makeMove(field);
             field.printField();
-            if (checkEndGame('O')) {
+            if (checkEndGame(GameSymbol.O)) {
                 break;
             }
         }
     }
 
-    public boolean checkEndGame(char dot) {
+    public boolean checkEndGame(GameSymbol dot) {
         if (field.checkWin(dot)) {
-            if (dot == 'X') {
+            if (dot == GameSymbol.X) {
                 System.out.println("Human wins!");
             } else {
                 System.out.println("AI wins!");
@@ -70,7 +71,7 @@ public class Game {
     private boolean isFieldFull() {
         for (int i = 0; i < field.getRows(); i++) {
             for (int j = 0; j < field.getColumns(); j++) {
-                if (field.getCell(i, j) == ' ') {
+                if (field.getCell(i, j) == GameSymbol.EMPTY) {
                     return false;
                 }
             }
@@ -78,3 +79,4 @@ public class Game {
         return true;
     }
 }
+

--- a/geekbrains/java-oop/TicTacToeAI/src/model/GameField.java
+++ b/geekbrains/java-oop/TicTacToeAI/src/model/GameField.java
@@ -10,10 +10,10 @@ public class GameField {
     private static final String ANSI_RED = "\u001B[31m";
     private static final String ANSI_RESET = "\u001B[0m";
 
-    private static final char DOT_EMPTY = ' ';
+    private GameSymbol DOT_EMPTY = GameSymbol.EMPTY;
     private int rows;
     private int columns;
-    private char[][] field;
+    private GameSymbol[][] field;
     private int requiredDots;
     private Scanner scanner;
     private InputValidator inputValidator;
@@ -37,7 +37,7 @@ public class GameField {
             }
         } while (requiredDots > Math.min(rows, columns));
 
-        field = new char[rows][columns];
+        field = new GameSymbol[rows][columns];
 
         for (int i = 0; i < rows; i++) {
             for (int j = 0; j < columns; j++) {
@@ -62,9 +62,9 @@ public class GameField {
         for (int i = 0; i < rows; i++) {
             System.out.printf("%3d │", (i + 1));
             for (int j = 0; j < columns; j++) {
-                if (field[i][j] == 'X') {
+                if (field[i][j] == GameSymbol.X) {
                     System.out.print(" " + ANSI_BLUE + field[i][j] + ANSI_RESET + " ");
-                } else if (field[i][j] == 'O') {
+                } else if (field[i][j] == GameSymbol.O) {
                     System.out.print(" " + ANSI_RED + field[i][j] + ANSI_RESET + " ");
                 } else {
                     System.out.print(" " + field[i][j] + " ");
@@ -97,15 +97,15 @@ public class GameField {
         return columns;
     }
 
-    public char getCell(int x, int y) {
+    public GameSymbol getCell(int x, int y) {
         return field[x][y];
     }
 
-    public void setCell(int x, int y, char dot) {
+    public void setCell(int x, int y, GameSymbol dot) {
         field[x][y] = dot;
     }
 
-    public boolean checkLine(int x, int y, int vx, int vy, char c) {
+    public boolean checkLine(int x, int y, int vx, int vy, GameSymbol c) {
         int wayX = x + (requiredDots - 1) * vx;
         int wayY = y + (requiredDots - 1) * vy;
 
@@ -122,7 +122,7 @@ public class GameField {
         return true;
     }
 
-    public boolean checkWin(char c) {
+    public boolean checkWin(GameSymbol c) {
         for (int i = 0; i < rows; i++) {
             for (int j = 0; j < columns; j++) {
                 if (field[i][j] == c) {
@@ -149,6 +149,7 @@ public class GameField {
     }
 
     public boolean isCellEmpty(int x, int y) {
-        return field[x][y] == DOT_EMPTY;
+        return field[x][y] == GameSymbol.EMPTY;
     }
 }
+

--- a/geekbrains/java-oop/TicTacToeAI/src/model/GameSymbol.java
+++ b/geekbrains/java-oop/TicTacToeAI/src/model/GameSymbol.java
@@ -1,0 +1,16 @@
+package model;
+
+public enum GameSymbol {
+    X, O, EMPTY;
+
+    @Override
+    public String toString() {
+        switch(this) {
+            case X: return "X";
+            case O: return "O";
+            case EMPTY: return " ";
+            default: throw new IllegalArgumentException();
+        }
+    }
+}
+

--- a/geekbrains/java-oop/TicTacToeAI/src/player/AIPlayer.java
+++ b/geekbrains/java-oop/TicTacToeAI/src/player/AIPlayer.java
@@ -1,6 +1,7 @@
 package player;
 
 import model.GameField;
+import model.GameSymbol;
 
 public class AIPlayer implements Player {
     private static final int MAX_DEPTH = 5;
@@ -8,11 +9,11 @@ public class AIPlayer implements Player {
     @Override
     public void makeMove(GameField field) {
         int[] result = minimax(MAX_DEPTH, Integer.MIN_VALUE, Integer.MAX_VALUE, field, true);
-        field.setCell(result[1], result[2], 'O');
+        field.setCell(result[1], result[2], GameSymbol.O);
     }
 
     private int[] minimax(int depth, int alpha, int beta, GameField field, boolean isMaximizingPlayer) {
-        if (depth == 0 || field.checkWin('O') || field.checkWin('X')) {
+        if (depth == 0 || field.checkWin(GameSymbol.O) || field.checkWin(GameSymbol.X)) {
             return new int[]{evaluateBoard(field), -1, -1};
         }
 
@@ -23,7 +24,7 @@ public class AIPlayer implements Player {
             for (int j = 0; j < field.getColumns(); j++) {
                 if (field.isCellEmpty(i, j)) {
                     if (isMaximizingPlayer) {
-                        field.setCell(i, j, 'O');
+                        field.setCell(i, j, GameSymbol.O);
                         int currentScore = minimax(depth - 1, alpha, beta, field, false)[0];
                         if (currentScore > alpha) {
                             alpha = currentScore;
@@ -31,7 +32,7 @@ public class AIPlayer implements Player {
                             bestY = j;
                         }
                     } else {
-                        field.setCell(i, j, 'X');
+                        field.setCell(i, j, GameSymbol.X);
                         int currentScore = minimax(depth - 1, alpha, beta, field, true)[0];
                         if (currentScore < beta) {
                             beta = currentScore;
@@ -39,7 +40,7 @@ public class AIPlayer implements Player {
                             bestY = j;
                         }
                     }
-                    field.setCell(i, j, ' ');
+                    field.setCell(i, j, GameSymbol.EMPTY);
                     if (alpha >= beta) {
                         break;
                     }
@@ -53,30 +54,30 @@ public class AIPlayer implements Player {
         int score = 0;
         for (int i = 0; i < field.getRows(); i++) {
             for (int j = 0; j < field.getColumns(); j++) {
-                if (field.getCell(i, j) == 'O') {
-                    if (field.checkLine(i, j, 0, 1, 'O')) {
+                if (field.getCell(i, j) == GameSymbol.O) {
+                    if (field.checkLine(i, j, 0, 1, GameSymbol.O)) {
                         score += 10;
                     }
-                    if (field.checkLine(i, j, 1, 0, 'O')) {
+                    if (field.checkLine(i, j, 1, 0, GameSymbol.O)) {
                         score += 10;
                     }
-                    if (field.checkLine(i, j, 1, 1, 'O')) {
+                    if (field.checkLine(i, j, 1, 1, GameSymbol.O)) {
                         score += 10;
                     }
-                    if (field.checkLine(i, j, -1, 1, 'O')) {
+                    if (field.checkLine(i, j, -1, 1, GameSymbol.O)) {
                         score += 10;
                     }
-                } else if (field.getCell(i, j) == 'X') {
-                    if (field.checkLine(i, j, 0, 1, 'X')) {
+                } else if (field.getCell(i, j) == GameSymbol.X) {
+                    if (field.checkLine(i, j, 0, 1, GameSymbol.X)) {
                         score -= 10;
                     }
-                    if (field.checkLine(i, j, 1, 0, 'X')) {
+                    if (field.checkLine(i, j, 1, 0, GameSymbol.X)) {
                         score -= 10;
                     }
-                    if (field.checkLine(i, j, 1, 1, 'X')) {
+                    if (field.checkLine(i, j, 1, 1, GameSymbol.X)) {
                         score -= 10;
                     }
-                    if (field.checkLine(i, j, -1, 1, 'X')) {
+                    if (field.checkLine(i, j, -1, 1, GameSymbol.X)) {
                         score -= 10;
                     }
                 }

--- a/geekbrains/java-oop/TicTacToeAI/src/player/HumanPlayer.java
+++ b/geekbrains/java-oop/TicTacToeAI/src/player/HumanPlayer.java
@@ -1,6 +1,7 @@
 package player;
 
 import model.GameField;
+import model.GameSymbol;
 import validation.InputValidator;
 import validation.TwoNaturalNumbersValidator;
 import java.util.Scanner;
@@ -19,7 +20,6 @@ public class HumanPlayer implements Player {
             x = coordinates[0] - 1;
             y = coordinates[1] - 1;
         } while (!field.isCellValid(x, y) || !field.isCellEmpty(x, y));
-        field.setCell(x, y, 'X');
+        field.setCell(x, y, GameSymbol.X);
     }
 }
-


### PR DESCRIPTION
#comment Refactor Game, GameField, AIPlayer, and HumanPlayer classes to use GameSymbol enum instead of char for representing game symbols. This includes changes in getCell, setCell, checkLine, makeMove, evaluateBoard, and checkEndGame methods. Also, implement GameSymbol enum to represent game symbols. It includes X, O, and EMPTY as possible values

Affected: Game, GameField, AIPlayer, HumanPlayer, GameSymbol