### PR TITLE
refactor: Remove old InputValidator interface

### DIFF
--- a/geekbrains/java-oop/TicTacToeAI/src/validation/InputValidator.java
+++ b/geekbrains/java-oop/TicTacToeAI/src/validation/InputValidator.java
@@ -1,7 +1,0 @@
-package validation;
-
-public interface InputValidator {
-    int validateNumber();
-    int[] validateNumbers();
-    String validateSymbol();
-}


### PR DESCRIPTION
#comment Removed the old InputValidator interface as it is no longer used. This action ensures that the codebase does not contain unused code

Affected: InputValidator