### PR TITLE
feat: Write serialized grid state to file

### DIFF
--- a/geekbrains/java-api/GridStateSerializer/src/GridStateFileWriter.java
+++ b/geekbrains/java-api/GridStateSerializer/src/GridStateFileWriter.java
@@ -1,0 +1,16 @@
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+public class GridStateFileWriter {
+    public void writeToFile(int serializedState, String fileName) {
+        try (FileOutputStream outputStream = new FileOutputStream(fileName)) {
+            outputStream.write((serializedState >> 16) & 0xFF);
+            outputStream.write((serializedState >> 8) & 0xFF);
+            outputStream.write(serializedState & 0xFF);
+            System.out.println("Grid state has been successfully written to the file.");
+        } catch (IOException e) {
+            System.out.println("An error occurred while writing the grid state to the file.");
+            e.printStackTrace();
+        }
+    }
+}


### PR DESCRIPTION
#comment Added a method to write the serialized state of the grid to a file. The writeToFile method in the GridStateFileWriter class takes an integer and a file name as input and writes the integer to the file in three bytes

Affected: GridStateFileWriter (writeToFile method), Main (file writing)