### PR TITLE
refactor: Use BufferedReader for file reading

### DIFF
--- a/yandex-academy/open-lectures-2022/Socks/src/function/SockThicknessCalculator.java
+++ b/yandex-academy/open-lectures-2022/Socks/src/function/SockThicknessCalculator.java
@@ -1,20 +1,21 @@
 package function;
 
-import java.util.List;
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
 
 public class SockThicknessCalculator implements SockThicknessCalculatorInterface {
-
     private int l;
     private int n;
     private int m;
-    private List<String> data;
+    private String filePath;
     private int[] pointsOfInterest;
 
-    public SockThicknessCalculator(int l, int n, int m, List<String> data, int[] pointsOfInterest) {
+    public SockThicknessCalculator(int l, int n, int m, String filePath, int[] pointsOfInterest) {
         this.l = l;
         this.n = n;
         this.m = m;
-        this.data = data;
+        this.filePath = filePath;
         this.pointsOfInterest = pointsOfInterest;
     }
 
@@ -22,12 +23,19 @@ public class SockThicknessCalculator implements SockThicknessCalculatorInterface
     public void calculateThickness() {
         int[] balance = new int[l + 1];
 
-        for (int i = 0; i < n; i++) {
-            String[] parts = data.get(i).split("\\s+");
-            int left = Integer.parseInt(parts[0]);
-            int right = Integer.parseInt(parts[1]);
-            balance[left - 1] += 1;
-            balance[right] -= 1;
+        try (BufferedReader reader = new BufferedReader(new FileReader(filePath))) {
+            String line;
+            for (int i = 0; i < n; i++) {
+                line = reader.readLine();
+                String[] parts = line.split("\\s+");
+                int left = Integer.parseInt(parts[0]);
+                int right = Integer.parseInt(parts[1]);
+                balance[left - 1] += 1;
+                balance[right] -= 1;
+            }
+        } catch (IOException e) {
+            System.out.println("Error reading the file: " + e.getMessage());
+            return;
         }
 
         int now = 0;

--- a/yandex-academy/open-lectures-2022/Socks/src/main/Main.java
+++ b/yandex-academy/open-lectures-2022/Socks/src/main/Main.java
@@ -4,9 +4,10 @@ import function.SockThicknessCalculator;
 import function.SockThicknessCalculatorInterface;
 import validation.*;
 
+import java.io.BufferedReader;
+import java.io.FileReader;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Scanner;
 
@@ -20,7 +21,6 @@ public class Main {
             return;
         }
 
-        List<String> data = Files.readAllLines(Path.of(filePath));
         fileValidator.notifyFileReadSuccessfully();
 
         InputValidator inputValidator = new TableSocksPointsValidator(scanner);
@@ -34,7 +34,7 @@ public class Main {
         GirlsInterestPointsValidatorInterface pointValidator = new GirlsInterestPointsValidator(scanner, m);
         int[] pointsOfInterest = pointValidator.validateInterestPoints();
 
-        SockThicknessCalculatorInterface calculator = new SockThicknessCalculator(l, n, m, data, pointsOfInterest);
+        SockThicknessCalculatorInterface calculator = new SockThicknessCalculator(l, n, m, filePath, pointsOfInterest);
         calculator.calculateThickness();
 
         scanner.close();


### PR DESCRIPTION
#comment Modify SockThicknessCalculator to read the file line by line using BufferedReader instead of reading all lines at once. Update Main class to pass the file path to SockThicknessCalculator, aligning with the refactor to use BufferedReader for file reading. This change enhances memory efficiency and is particularly beneficial for large files

Affected: SockThicknessCalculator, Main (file reading)