### PR TITLE
feat: Separate thickness calculation and printing

### DIFF
--- a/yandex-academy/open-lectures-2022/Socks/src/function/SockThicknessCalculator.java
+++ b/yandex-academy/open-lectures-2022/Socks/src/function/SockThicknessCalculator.java
@@ -20,7 +20,7 @@ public class SockThicknessCalculator implements SockThicknessCalculatorInterface
     }
 
     @Override
-    public void calculateThickness() {
+    public int[] calculateThickness() {
         int[] balance = new int[l + 1];
 
         try (BufferedReader reader = new BufferedReader(new FileReader(filePath))) {
@@ -35,7 +35,7 @@ public class SockThicknessCalculator implements SockThicknessCalculatorInterface
             }
         } catch (IOException e) {
             System.out.println("Error reading the file: " + e.getMessage());
-            return;
+            return null;
         }
 
         int now = 0;
@@ -45,7 +45,10 @@ public class SockThicknessCalculator implements SockThicknessCalculatorInterface
             now = now + balance[i];
             thickness[i] = now;
         }
+        return thickness;
+    }
 
+    public void printThickness(int[] thickness) {
         for (int i = 0; i < m; i++) {
             int query = pointsOfInterest[i];
             System.out.println("Thickness of sock coating at point " + query + ": " + thickness[query - 1]);

--- a/yandex-academy/open-lectures-2022/Socks/src/function/SockThicknessCalculatorInterface.java
+++ b/yandex-academy/open-lectures-2022/Socks/src/function/SockThicknessCalculatorInterface.java
@@ -1,5 +1,5 @@
 package function;
 
 public interface SockThicknessCalculatorInterface {
-    void calculateThickness();
+    int[] calculateThickness();
 }

--- a/yandex-academy/open-lectures-2022/Socks/src/main/Main.java
+++ b/yandex-academy/open-lectures-2022/Socks/src/main/Main.java
@@ -4,10 +4,7 @@ import function.SockThicknessCalculator;
 import function.SockThicknessCalculatorInterface;
 import validation.*;
 
-import java.io.BufferedReader;
-import java.io.FileReader;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Scanner;
 
@@ -35,7 +32,11 @@ public class Main {
         int[] pointsOfInterest = pointValidator.validateInterestPoints();
 
         SockThicknessCalculatorInterface calculator = new SockThicknessCalculator(l, n, m, filePath, pointsOfInterest);
-        calculator.calculateThickness();
+        int[] thickness = calculator.calculateThickness();
+
+        if (thickness != null) {
+            ((SockThicknessCalculator) calculator).printThickness(thickness);
+        }
 
         scanner.close();
     }


### PR DESCRIPTION
#comment Split the calculateThickness method into two methods in SockThicknessCalculator: one for calculation (calculateThickness) and one for printing results (printThickness). Adjust the Main class to use these new methods. This enhances code readability and maintainability

Affected: SockThicknessCalculator, SockThicknessCalculatorInterface, Main (calculation and printing separation)