### PR TITLE
refactor: Improve interface usage

### DIFF
--- a/yandex-academy/open-lectures-2022/Socks/src/function/SockThicknessCalculator.java
+++ b/yandex-academy/open-lectures-2022/Socks/src/function/SockThicknessCalculator.java
@@ -48,6 +48,7 @@ public class SockThicknessCalculator implements SockThicknessCalculatorInterface
         return thickness;
     }
 
+    @Override
     public void printThickness(int[] thickness) {
         for (int i = 0; i < m; i++) {
             int query = pointsOfInterest[i];

--- a/yandex-academy/open-lectures-2022/Socks/src/function/SockThicknessCalculatorInterface.java
+++ b/yandex-academy/open-lectures-2022/Socks/src/function/SockThicknessCalculatorInterface.java
@@ -2,4 +2,5 @@ package function;
 
 public interface SockThicknessCalculatorInterface {
     int[] calculateThickness();
+    void printThickness(int[] thickness);
 }

--- a/yandex-academy/open-lectures-2022/Socks/src/main/Main.java
+++ b/yandex-academy/open-lectures-2022/Socks/src/main/Main.java
@@ -35,7 +35,7 @@ public class Main {
         int[] thickness = calculator.calculateThickness();
 
         if (thickness != null) {
-            ((SockThicknessCalculator) calculator).printThickness(thickness);
+            calculator.printThickness(thickness);
         }
 
         scanner.close();


### PR DESCRIPTION
#comment Add printThickness method to SockThicknessCalculatorInterface and update SockThicknessCalculator and Main classes to use this method, avoiding explicit type casting

Affected: SockThicknessCalculatorInterface, SockThicknessCalculator, Main