### PR TITLE
refactor: Update SockThicknessCalculatorInterface for List

### DIFF
--- a/yandex-academy/open-lectures-2022/Socks/src/function/SockThicknessCalculatorInterface.java
+++ b/yandex-academy/open-lectures-2022/Socks/src/function/SockThicknessCalculatorInterface.java
@@ -1,6 +1,8 @@
 package function;
 
+import java.util.List;
+
 public interface SockThicknessCalculatorInterface {
-    int[] calculateThickness();
-    void printThickness(int[] thickness);
+    List<Integer> calculateThickness();
+    void printThickness(List<Integer> thickness);
 }


### PR DESCRIPTION
#comment Modify SockThicknessCalculatorInterface to reflect changes in SockThicknessCalculator. Methods now work with List<Integer> instead of int[]

Affected: SockThicknessCalculatorInterface (method signatures)