### PR TITLE
refactor: Improve variable naming clarity in SockThicknessCalculator

### DIFF
--- a/yandex-academy/open-lectures-2022/Socks/src/function/SockThicknessCalculator.java
+++ b/yandex-academy/open-lectures-2022/Socks/src/function/SockThicknessCalculator.java
@@ -44,12 +44,12 @@ public class SockThicknessCalculator implements SockThicknessCalculatorInterface
             return null;
         }
 
-        int now = 0;
+        int currentThickness = 0;
         List<Integer> thickness = new ArrayList<>();
 
         for (int i = 0; i < l; i++) {
-            now = now + balance.get(i);
-            thickness.add(now);
+            currentThickness = currentThickness + balance.get(i);
+            thickness.add(currentThickness);
         }
         return thickness;
     }


### PR DESCRIPTION
#comment Renamed the 'now' variable to 'currentThickness' for better code readability and understanding

Affected: SockThicknessCalculator (variable naming)