### PR TITLE
feat: Introduce custom exception for file reading errors

### DIFF
--- a/yandex-academy/open-lectures-2022/Socks/src/exceptions/FileReadingException.java
+++ b/yandex-academy/open-lectures-2022/Socks/src/exceptions/FileReadingException.java
@@ -1,0 +1,7 @@
+package exceptions;
+
+public class FileReadingException extends Exception {
+    public FileReadingException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}


### PR DESCRIPTION
#comment Introduced a custom exception named FileReadingException to better handle file reading errors, providing more context and clarity

Affected: FileReadingException