### PR TITLE
refactor: Convert isInteger to static method

### DIFF
--- a/yandex-academy/open-lectures-2022/Socks/src/function/SockThicknessCalculator.java
+++ b/yandex-academy/open-lectures-2022/Socks/src/function/SockThicknessCalculator.java
@@ -46,7 +46,7 @@ public class SockThicknessCalculator implements SockThicknessCalculatorInterface
         }
     }
 
-    private boolean isInteger(String s) {
+    private static boolean isInteger(String s) {
         try {
             Integer.parseInt(s);
             return true;


### PR DESCRIPTION
#comment Modify isInteger method in SockThicknessCalculator to be a static utility method since it doesn't rely on object state

Affected: SockThicknessCalculator (method isInteger)