### PR TITLE
refactor: Modify SockThicknessCalculator constructor params

### DIFF
--- a/yandex-academy/open-lectures-2022/Socks/src/function/SockThicknessCalculator.java
+++ b/yandex-academy/open-lectures-2022/Socks/src/function/SockThicknessCalculator.java
@@ -1,11 +1,6 @@
 package function;
 
-import exceptions.FileReadingException;
 import exceptions.InvalidFileDataException;
-import java.io.BufferedReader;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -13,35 +8,25 @@ public class SockThicknessCalculator implements SockThicknessCalculatorInterface
     private int l;
     private int n;
     private int m;
-    private String filePath;
+    private List<String> fileLines;
     private List<Integer> pointsOfInterest;
 
-    public SockThicknessCalculator(int l, int n, int m, String filePath, List<Integer> pointsOfInterest) {
+    public SockThicknessCalculator(int l, int n, int m, List<String> fileLines, List<Integer> pointsOfInterest) {
         this.l = l;
         this.n = n;
         this.m = m;
-        this.filePath = filePath;
+        this.fileLines = fileLines;
         this.pointsOfInterest = pointsOfInterest;
     }
 
-    private List<String> readFileLines() throws FileReadingException {
-        try {
-            return Files.readAllLines(Paths.get(filePath));
-        } catch (IOException e) {
-            throw new FileReadingException("Error reading file: " + filePath, e);
-        }
-    }
-
     public void validateFileData() throws InvalidFileDataException {
-        List<String> lines = readFileLines();
-
         int lineNumber = 0;
 
-        for (String line : lines) {
+        for (String line : fileLines) {
             lineNumber++;
             String[] parts = line.split("\\s+");
             if (parts.length != 2 || !isInteger(parts[0]) || !isInteger(parts[1])) {
-                throw new InvalidFileDataException("Invalid data format in " + filePath + " at line: " + lineNumber);
+                throw new InvalidFileDataException("Invalid data format at line: " + lineNumber);
             }
         }
     }
@@ -56,16 +41,14 @@ public class SockThicknessCalculator implements SockThicknessCalculatorInterface
     }
 
     @Override
-    public List<Integer> calculateThickness() throws FileReadingException {
-        List<String> lines = readFileLines();
-
+    public List<Integer> calculateThickness() {
         List<Integer> balance = new ArrayList<>(l + 1);
         for (int i = 0; i <= l; i++) {
             balance.add(0);
         }
 
         for (int i = 0; i < n; i++) {
-            String[] parts = lines.get(i).split("\\s+");
+            String[] parts = fileLines.get(i).split("\\s+");
             int left = Integer.parseInt(parts[0]);
             int right = Integer.parseInt(parts[1]);
             balance.set(left - 1, balance.get(left - 1) + 1);


### PR DESCRIPTION
#comment Change constructor of SockThicknessCalculator to take fileLines as a parameter instead of filePath. Update relevant methods to utilize fileLines directly

Affected: SockThicknessCalculator (constructor and methods update)